### PR TITLE
Turn on the built-in minify options in HTML Webpack Plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
-    "babel-minify-webpack-plugin": "^0.3.1",
     "babel-preset-env": "^1.7.0",
     "babel-preset-minify": "^0.4.3",
     "clean-webpack-plugin": "^0.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulito",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Conventions and structure for a Vanilla JS application with a supporting webpack config.",
   "main": "webpack.common.js",
   "license": "Apache-2.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -42,6 +42,8 @@
 //          );
 //        }
 //
+//    Note that argv.mode will be set to either 'production', 'development',
+//    or '' depending on the --mode flag passed to the webpack cli.
 //
 // You do not need to add any of the plugins or loaders used here to your
 // local package.json, on the other hand, if you add new loaders or plugins
@@ -49,10 +51,10 @@
 // package.json.
 //
 //     build:
-//        npx webpack --mode=development
+//      	npx webpack --mode=development
 //
 //     release:
-//        npx webpack --mode=production
+//      	npx webpack --mode=production
 //
 const { glob } = require('glob');
 const path = require('path');


### PR DESCRIPTION
Presently, the output files aren't really minified at all.  The reason is that even though HtmlWebpackPlugin.minify is set to true, [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference), the underlying minification toolbox has most of its options set to off.

This PR turns them on and removes babel-minify-webpack-plugin which didn't seem to be doing much anyway.

One of the pages I was working on was 1051 bytes (614 bytes gzipped) before this CL and is 766 bytes (493 bytes gzipped) after.

It is possible for a client to do this, but I figure most users will want smaller output and these options are pretty safe for HTML5 pages and modern, evergreen browsers.

If a client were to do this, it would look something like:

```
module.exports = (env, argv) => {
  let config = commonBuilder(env, argv, __dirname);

  config.plugins.forEach( (p) => {
    if ('HtmlWebpackPlugin' === p.constructor.name && p.options) {
      p.options.minify = {
       // options here
     };
    }
  });
  return config;
}
```