### PR TITLE
Disable (unsafe) minification of keyframes by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulito",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Conventions and structure for a Vanilla JS application with a supporting webpack config.",
   "main": "webpack.common.js",
   "license": "Apache-2.0",
@@ -13,6 +13,7 @@
     "url": "https://github.com/google/pulito.git"
   },
   "dependencies": {
+    "autoprefixer": "^9.4.4",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.7.0",

--- a/prod/postcss.config.js
+++ b/prod/postcss.config.js
@@ -1,7 +1,16 @@
 // postcss config used in all production webpack.common.js configs.
 module.exports = {
-  plugins: {
-    'autoprefixer': {},
-    'cssnano': {}
-  }
+  plugins: [
+    require('autoprefixer')(),
+    require('cssnano')({
+      // Since cssnano ToT is at >4, the docs on the website are incorrect
+      // as to what is and is not on by default. Further, the names
+      // appear to have changed slightly. Until pulito is upgraded to
+      // use cssnano 4.0, the best place to look for the real names is
+      // https://github.com/cssnano/cssnano/blob/v3.10.0/metadata.toml
+      'postcss-reduce-idents': false,
+      'postcss-discard-overridden': false,
+      'postcss-discard-unused': false,
+    }),
+  ]
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -51,10 +51,10 @@
 // package.json.
 //
 //     build:
-//      	npx webpack --mode=development
+//        npx webpack --mode=development
 //
 //     release:
-//      	npx webpack --mode=production
+//        npx webpack --mode=production
 //
 const { glob } = require('glob');
 const path = require('path');
@@ -68,6 +68,8 @@ const minifyOptions = {
   caseSensitive: true,
   collapseBooleanAttributes: true,
   collapseWhitespace: true,
+  // this handles CSS minification in the .js files. For options
+  // involving minifying .[s]css files, see ./**/postcss.config.js
   minifyCSS: true,
   minifyJS: true,
   minifyURLS: true,
@@ -222,6 +224,8 @@ module.exports = (env, argv, dirname) => {
   // The postcss config file must be named postcss.config.js, so we store the
   // different configs in different dirs.
   let prefix = argv.mode === 'production' ? 'prod' : 'dev';
+  // This file handles minification, auto-prefixing, etc. See there for configuring
+  // those plugins.
   let postCssConfig = path.resolve(__dirname, prefix, 'postcss.config.js');
   let common = {
     entry: {


### PR DESCRIPTION
These unsafe options have been turned off in v4.0 of cssnano.

Adds some forwarding docs to make this sort of thing easier to find in the future.

Also adds a forgotten dep (autoprefixer).